### PR TITLE
Fixed a potential concurrency bug

### DIFF
--- a/plains/src/main/java/org/openspaces/plains/datagrid/DataGridConnectionUtility.java
+++ b/plains/src/main/java/org/openspaces/plains/datagrid/DataGridConnectionUtility.java
@@ -1,6 +1,10 @@
 package org.openspaces.plains.datagrid;
 
-import com.j_spaces.core.IJSpace;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import org.openspaces.admin.Admin;
 import org.openspaces.admin.AdminFactory;
 import org.openspaces.admin.gsm.GridServiceManager;
@@ -12,14 +16,14 @@ import org.openspaces.core.space.CannotFindSpaceException;
 import org.openspaces.core.space.UrlSpaceConfigurer;
 import org.openspaces.core.space.cache.LocalCacheSpaceConfigurer;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import com.j_spaces.core.IJSpace;
 
 public final class DataGridConnectionUtility {
-    Map<String, UrlSpaceConfigurer> configurerMap = new ConcurrentHashMap<String, UrlSpaceConfigurer>();
-    Map<String, GigaSpace> gigaSpaceMap = new ConcurrentHashMap<String, GigaSpace>();
+    Map<String, UrlSpaceConfigurer> configurerMap = new HashMap<String, UrlSpaceConfigurer>();
+    Map<String, GigaSpace> gigaSpaceMap = new HashMap<String, GigaSpace>();
+    // Single lock object that guards access to the gigaSpaceMap and the configurerMap
+    final Object mapLock = new Object();
+    
     Logger log = Logger.getLogger(this.getClass().getName());
 
     static DataGridConnectionUtility instance = new DataGridConnectionUtility();
@@ -28,40 +32,46 @@ public final class DataGridConnectionUtility {
         Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override
             public void run() {
-                for (UrlSpaceConfigurer configurer : configurerMap.values()) {
-                    try {
-                        log.fine("Shutting down configurer " + configurer);
-                        configurer.destroy();
-                    } catch (Exception e) {
-                        log.log(Level.SEVERE, e.getMessage(), e);
-                    }
-                }
+            	// You can lock here rather than use a ConcurrentHashMap for configurerMap. 
+            	// The argument being that we're shutting down now and playtime is over.
+            	synchronized (mapLock) {
+	                for (UrlSpaceConfigurer configurer : configurerMap.values()) {
+	                    try {
+	                        log.fine("Shutting down configurer " + configurer);
+	                        configurer.destroy();
+	                    } catch (Exception e) {
+	                        log.log(Level.SEVERE, e.getMessage(), e);
+	                    }
+	                }
+            	}
             }
         });
     }
 
     public static GigaSpace getSpace(String spaceName, int instances, int backups) {
-        GigaSpace gigaspace = instance.gigaSpaceMap.get(spaceName);
-        if (gigaspace == null) {
-            UrlSpaceConfigurer configurer = new UrlSpaceConfigurer("jini:/*/*/" + spaceName);
-            instance.configurerMap.put(spaceName, configurer);
-            IJSpace space = null;
-            try {
-                space = configurer.space();
-            } catch (CannotFindSpaceException cfse) {
-                Admin admin = new AdminFactory().createAdmin();
-                GridServiceManager esm = admin.getGridServiceManagers().waitForAtLeastOne();
-                ProcessingUnit pu = esm.deploy(new SpaceDeployment(spaceName)
-                        .partitioned(instances, backups));
-                pu.waitForSpace();
-                admin.close();
-                space = configurer.space();
-            }
-            LocalCacheSpaceConfigurer cacheConfigurer = new LocalCacheSpaceConfigurer(space);
-            gigaspace = new GigaSpaceConfigurer(cacheConfigurer.space()).gigaSpace();
-            instance.gigaSpaceMap.put(spaceName, gigaspace);
-        }
-        return gigaspace;
+    	synchronized (instance.mapLock) {
+	        GigaSpace gigaspace = instance.gigaSpaceMap.get(spaceName);
+	        if (gigaspace == null) {
+	            UrlSpaceConfigurer configurer = new UrlSpaceConfigurer("jini:/*/*/" + spaceName);
+	            instance.configurerMap.put(spaceName, configurer);
+	            IJSpace space = null;
+	            try {
+	                space = configurer.space();
+	            } catch (CannotFindSpaceException cfse) {
+	                Admin admin = new AdminFactory().createAdmin();
+	                GridServiceManager esm = admin.getGridServiceManagers().waitForAtLeastOne();
+	                ProcessingUnit pu = esm.deploy(new SpaceDeployment(spaceName)
+	                        .partitioned(instances, backups));
+	                pu.waitForSpace();
+	                admin.close();
+	                space = configurer.space();
+	            }
+	            LocalCacheSpaceConfigurer cacheConfigurer = new LocalCacheSpaceConfigurer(space);
+	            gigaspace = new GigaSpaceConfigurer(cacheConfigurer.space()).gigaSpace();
+	            instance.gigaSpaceMap.put(spaceName, gigaspace);
+	        }
+	        return gigaspace;
+		}
 
     }
 


### PR DESCRIPTION
Hi guys,

I was going through your documentation and stumbled across this page recommending the use of a utility class

http://www.gigaspaces.com/wiki/display/XAP8/Setting+Up+Your+First+Data+Grid

When I opened the link I spotted these problems. The concurrent hash map protects against concurrent access but this is not a replacement for transactions. In fact you do not need the concurrent hash map at all in this case because nobody is editing it outside of getSpaces. It's been replaced with a locking structure that guards transactional areas that need both maps. 

Please review.
